### PR TITLE
Add riscv32im to build.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radium"
-version = "0.7.0"
+version = "0.7.1"
 authors = [
     "Nika Layzell <nika@thelayzells.com>",
     "myrrlyn <self@myrrlyn.dev>"

--- a/build.rs
+++ b/build.rs
@@ -89,7 +89,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         // both `target_arch = "riscv32", and have no stable `cfg`-discoverable
         // distinction. As such, the non-atomic RISC-V targets must be
         // discovered here.
-        "riscv32i" | "riscv32imc" | "thumbv6m" => atomics = Atomics::NONE,
+        "riscv32i" | "riscv32im" | "riscv32imc" | "thumbv6m" => atomics = Atomics::NONE,
         _ => {}
     }
     #[allow(clippy::match_single_binding, clippy::single_match)]


### PR DESCRIPTION
riscv32im is supported in rust nightly. This PR adds it to the list of targets with `atomics = Atomics::NONE`

cc @flaub